### PR TITLE
Removed extra whitespace from the label

### DIFF
--- a/src/InlineInput.svelte
+++ b/src/InlineInput.svelte
@@ -101,11 +101,6 @@ const handleChange = (e) => {
   <span
     class={labelClasses}
     on:click={toggle}>
-    {label}
-    <slot name="selectCaret">
-      {#if isSelect}
-        <span>&#9660;</span>
-      {/if}
-    </slot>
+    {label}<slot name="selectCaret">{#if isSelect}<span>&#9660;</span>{/if}</slot>
   </span>
 {/if}


### PR DESCRIPTION
The whitespace was caused by a newline in the Label <span>.
Fixes issue #5